### PR TITLE
fix: remove expired DB binding from render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,3 @@
-databases:
-  - name: splitly-db
-    plan: free
-    databaseName: splitly
-    user: splitly
-
 services:
   - type: web
     name: splitly-api
@@ -16,9 +10,7 @@ services:
       - key: ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: splitly-db
-          property: connectionString
+        sync: false
       - key: FIREBASE_CREDENTIALS_JSON
         sync: false
       - key: PYTHON_VERSION


### PR DESCRIPTION
## Summary
- 移除已過期的 `databases` 區塊（舊的 `splitly-db` free tier 已到期）
- `DATABASE_URL` 改為 `sync: false`，由 Render Dashboard 手動管理

## 部署步驟
1. 先到 Render Dashboard 填入新的 `DATABASE_URL`
2. Merge 此 PR
3. 部署成功後打 seed endpoint 補回 demo 資料

🤖 Generated with [Claude Code](https://claude.com/claude-code)