### PR TITLE
feat: switch database to Supabase PostgreSQL

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,5 +13,7 @@ services:
         sync: false
       - key: FIREBASE_CREDENTIALS_JSON
         sync: false
+      - key: SEED_SECRET
+        sync: false
       - key: PYTHON_VERSION
         value: "3.11"

--- a/server/src/database/relational_db.py
+++ b/server/src/database/relational_db.py
@@ -10,18 +10,18 @@ from src.database.models.base import Base
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-# Render 的 PostgreSQL URL 用 postgres://，SQLAlchemy 需要 postgresql://
 if DATABASE_URL and DATABASE_URL.startswith("postgres://"):
     DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
 ECHO_SQL = os.getenv("ENV", "dev") == "dev"
 
 engine = create_engine(
     DATABASE_URL,
-    pool_size=10,        # 原本是 5，增加連線數
-    max_overflow=20,     # 容許額外等待的請求數
-    pool_timeout=30,     # 等待連線最大秒數
+    pool_size=5,
+    max_overflow=10,
+    pool_timeout=30,
+    pool_pre_ping=True,
     echo=ECHO_SQL,
-    future=True    
+    future=True
 )
 
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)


### PR DESCRIPTION
## Summary
- 調整 SQLAlchemy 連線池設定，適配 Supabase free tier（降低 pool_size/max_overflow，新增 `pool_pre_ping` 偵測斷線重連）
- 在 `render.yaml` 補上 `SEED_SECRET` 環境變數宣告

## Merge 後需手動操作
1. 在 Supabase 建立新的 PostgreSQL 專案
2. 複製 Supabase 的 connection string（建議用 **Transaction Pooler**，port 6543）
3. 到 Render Dashboard → Environment → 更新 `DATABASE_URL` 為 Supabase 連線字串
4. 設定 `SEED_SECRET` 環境變數
5. 重新部署，確認 build 成功（Alembic migration 會自動跑）
6. 執行 seed endpoint 初始化資料

## Test plan
- [ ] Render build 成功（Alembic migration 正常）
- [ ] `/api/demo/seed` endpoint 可正常 seed 資料
- [ ] 登入流程正常（`/api/auth/user` 回 200）
- [ ] 連線中斷後自動重連（pool_pre_ping 生效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)